### PR TITLE
BF7 - Hotfix regarding opened json files

### DIFF
--- a/interactive_noisy_simulation/noise_creator.py
+++ b/interactive_noisy_simulation/noise_creator.py
@@ -17,13 +17,13 @@ from . import data
 from .noise_data_manager import NoiseDataManager
 
 
-with (resources.files(data) / "config.json").open("r") as file:
+with (resources.files(data) / "config.json").open("r", encoding="utf8") as file:
     CONFIG = json.load(file)
 
-with (resources.files(data) / "csv_columns.json").open("r") as file:
+with (resources.files(data) / "csv_columns.json").open("r", encoding="utf8") as file:
     CSV_COLUMNS = json.load(file)
     
-with (resources.files(data) / "messages.json").open("r") as file:
+with (resources.files(data) / "messages.json").open("r", encoding="utf8") as file:
     MESSAGES = json.load(file)
 
 

--- a/interactive_noisy_simulation/noise_data_manager.py
+++ b/interactive_noisy_simulation/noise_data_manager.py
@@ -10,13 +10,13 @@ import numpy, pandas
 from . import data
 
 
-with (resources.files(data) / "config.json").open("r") as file:
+with (resources.files(data) / "config.json").open("r", encoding="utf8") as file:
     CONFIG = json.load(file)
 
-with (resources.files(data) / "csv_columns.json").open("r") as file:
+with (resources.files(data) / "csv_columns.json").open("r", encoding="utf8") as file:
     CSV_COLUMNS = json.load(file)
     
-with (resources.files(data) / "messages.json").open("r") as file:
+with (resources.files(data) / "messages.json").open("r", encoding="utf8") as file:
     MESSAGES = json.load(file)
 
 

--- a/interactive_noisy_simulation/simulator_manager.py
+++ b/interactive_noisy_simulation/simulator_manager.py
@@ -12,7 +12,7 @@ from . import data
 from .noise_creator import NoiseCreator
 
 
-with (resources.files(data) / "messages.json").open("r") as file:
+with (resources.files(data) / "messages.json").open("r", encoding="utf8") as file:
     MESSAGES = json.load(file)
 
 


### PR DESCRIPTION
There was an issue with Jupyter Notebook, where the following error was present:
 `'charmap' codec can't decode byte 0x88 in position 680: character maps to <undefined>`

Specifying the `encoding` format and setting it to `utf8` while opening the json files fixed the issue.